### PR TITLE
Just a start. Adding a folder for testing simple yaml string cases.

### DIFF
--- a/test/2.0-ideas/fenced_strings/info
+++ b/test/2.0-ideas/fenced_strings/info
@@ -1,0 +1,24 @@
+So the idea behind this, is that it is much easier to remember how to use. 
+
+The logic is that single " in string_folded in is essentially a split up version of `string_folded: " ... "`
+
+While for multi line... you would emphasis on it's multi line.
+
+This is better than saying `|` and `>`, which is rather abstract. 
+
+
+string_multiline:
+   """
+   This is a multiline
+   in yaml source
+   it is made up of 
+   lots of lines
+   """
+   
+string_folded:
+   "
+   This is a multiline
+   in yaml source
+   it is made up of 
+   lots of lines
+   "

--- a/test/2.0-ideas/fenced_strings/test.json
+++ b/test/2.0-ideas/fenced_strings/test.json
@@ -1,0 +1,4 @@
+{
+string_multiline:"This is a multiline \nin yaml source \nit is made up of \nlots of lines",
+string_folded: "This is a multiline in yaml source it is made up of lots of lines"
+}

--- a/test/2.0-ideas/fenced_strings/test.yaml
+++ b/test/2.0-ideas/fenced_strings/test.yaml
@@ -1,0 +1,15 @@
+string_multiline:
+   """
+   This is a multiline
+   in yaml source
+   it is made up of 
+   lots of lines
+   """
+   
+string_folded:
+   "
+   This is a multiline
+   in yaml source
+   it is made up of 
+   lots of lines
+   "

--- a/test/JSON/docbook/test.json
+++ b/test/JSON/docbook/test.json
@@ -1,0 +1,22 @@
+{
+    "glossary": {
+        "title": "example glossary",
+		"GlossDiv": {
+            "title": "S",
+			"GlossList": {
+                "GlossEntry": {
+                    "ID": "SGML",
+					"SortAs": "SGML",
+					"GlossTerm": "Standard Generalized Markup Language",
+					"Acronym": "SGML",
+					"Abbrev": "ISO 8879:1986",
+					"GlossDef": {
+                        "para": "A meta-markup language, used to create markup languages such as DocBook.",
+						"GlossSeeAlso": ["GML", "XML"]
+                    },
+					"GlossSee": "markup"
+                }
+            }
+        }
+    }
+}

--- a/test/JSON/docbook/test.yaml
+++ b/test/JSON/docbook/test.yaml
@@ -1,0 +1,17 @@
+  glossary: 
+    title: "example glossary"
+    GlossDiv: 
+      title: "S"
+      GlossList: 
+        GlossEntry: 
+          ID: "SGML"
+          SortAs: "SGML"
+          GlossTerm: "Standard Generalized Markup Language"
+          Acronym: "SGML"
+          Abbrev: "ISO 8879:1986"
+          GlossDef: 
+            para: "A meta-markup language, used to create markup languages such as DocBook."
+            GlossSeeAlso: 
+              - "GML"
+              - "XML"
+          GlossSee: "markup"

--- a/test/JSON/info
+++ b/test/JSON/info
@@ -1,0 +1,2 @@
+These test, is gathered from http://json.org/example . And is a good test for designing a minimalistic YAML parser that has just enough feature to still work with JSON.
+

--- a/test/JSON/menu-config/test.json
+++ b/test/JSON/menu-config/test.json
@@ -1,0 +1,11 @@
+{"menu": {
+  "id": "file",
+  "value": "File",
+  "popup": {
+    "menuitem": [
+      {"value": "New", "onclick": "CreateNewDoc()"},
+      {"value": "Open", "onclick": "OpenDoc()"},
+      {"value": "Close", "onclick": "CloseDoc()"}
+    ]
+  }
+}}

--- a/test/JSON/menu-config/test.yaml
+++ b/test/JSON/menu-config/test.yaml
@@ -1,0 +1,14 @@
+  menu: 
+    id: "file"
+    value: "File"
+    popup: 
+      menuitem: 
+        - 
+          value: "New"
+          onclick: "CreateNewDoc()"
+        - 
+          value: "Open"
+          onclick: "OpenDoc()"
+        - 
+          value: "Close"
+          onclick: "CloseDoc()"

--- a/test/JSON/widget/test.json
+++ b/test/JSON/widget/test.json
@@ -1,0 +1,26 @@
+{"widget": {
+    "debug": "on",
+    "window": {
+        "title": "Sample Konfabulator Widget",
+        "name": "main_window",
+        "width": 500,
+        "height": 500
+    },
+    "image": { 
+        "src": "Images/Sun.png",
+        "name": "sun1",
+        "hOffset": 250,
+        "vOffset": 250,
+        "alignment": "center"
+    },
+    "text": {
+        "data": "Click Here",
+        "size": 36,
+        "style": "bold",
+        "name": "text1",
+        "hOffset": 250,
+        "vOffset": 100,
+        "alignment": "center",
+        "onMouseUp": "sun1.opacity = (sun1.opacity / 100) * 90;"
+    }
+}}

--- a/test/JSON/widget/test.yaml
+++ b/test/JSON/widget/test.yaml
@@ -1,0 +1,22 @@
+  widget: 
+    debug: "on"
+    window: 
+      title: "Sample Konfabulator Widget"
+      name: "main_window"
+      width: 500
+      height: 500
+    image: 
+      src: "Images/Sun.png"
+      name: "sun1"
+      hOffset: 250
+      vOffset: 250
+      alignment: "center"
+    text: 
+      data: "Click Here"
+      size: 36
+      style: "bold"
+      name: "text1"
+      hOffset: 250
+      vOffset: 100
+      alignment: "center"
+      onMouseUp: "sun1.opacity = (sun1.opacity / 100) * 90;"

--- a/test/datatypes-simple/info
+++ b/test/datatypes-simple/info
@@ -1,0 +1,15 @@
+This test was lifted from http://en.wikipedia.org/wiki/YAML#Syntax
+
+
+Simple datatype in this context is defined by all the supported datatype supported by JSON.
+
+------
+
+http://en.wikipedia.org/wiki/JSON#Data_types.2C_syntax_and_example
+
+Number — a signed decimal number that may contain a fractional part and may use exponential E notation. JSON does not allow non-numbers like NaN, nor does it make any distinction between integer and floating-point. (Even though JavaScript uses a double-precision floating-point format for all its numeric values, other languages implementing JSON may encode numbers differently)
+String — a sequence of zero or more Unicode characters. Strings are delimited with double-quotation marks and support a backslash escaping syntax.
+Boolean — either of the values true or false
+Array — an ordered list of zero or more values, each of which may be of any type. Arrays use square bracket notation with elements being comma-separated.
+Object — an unordered collection of name/value pairs where the names (also called keys) are strings. Since objects are intended to represent associative arrays,[10] it is recommended, though not required,[11] that each key is unique within an object. Objects are delimited with curly brackets and use commas to separate each pair, while within each pair the colon ':' character separates the key or name from its value.
+null — An empty value, using the word null

--- a/test/datatypes-simple/info
+++ b/test/datatypes-simple/info
@@ -1,3 +1,12 @@
+These are the simple data types you will find in json. 
+JSON's Basic Types According to http://en.wikipedia.org/wiki/JSON#Data_types.2C_syntax_and_example is:
+ - Number (No distinction between floats and integer)
+ - String ( "this is a string" )
+ - Boolean ( either [true, false] only)
+ - Array ( ordered list of values )
+ - Object (unordered collections of key:value pairs) 
+ - Null (no objects)
+
 This test was lifted from http://en.wikipedia.org/wiki/YAML#Syntax
 
 

--- a/test/datatypes-simple/test.json
+++ b/test/datatypes-simple/test.json
@@ -1,0 +1,57 @@
+{
+  "integer": 123,
+  "integer_str": "123",
+  "float_1": 123,
+  "float_2": 123.123,
+  "float_float": 123.123,
+  "float_str": "123.123",
+  "string_1": "123",
+  "string_2": "Yes",
+  "string_3": "Yes we have No bananas",
+  "string_multiline": "This is a multiline\nin yaml source\nit is made up of \nlots of lines\n",
+  "string_folded": "This is a multiline in yaml source it is made up of  lots of lines\n",
+  "bool_true_1": true,
+  "bool_true_2": true,
+  "bool_false_1": false,
+  "bool_false_2": false,
+  "array_1": [
+    1,
+    2,
+    3,
+    4,
+    5
+  ],
+  "array_2": [
+    1,
+    2,
+    3,
+    4,
+    5
+  ],
+  "associative_list": {
+    "name": "John Smith",
+    "age": 33
+  },
+  "assoc_array_1": [
+    {
+      "name": "Mary Smith",
+      "age": 27
+    },
+    {
+      "name": "Dan Tith",
+      "age": 23
+    }
+  ],
+  "assoc_array_2": [
+    {
+      "name": "Mary Smith",
+      "age": 27
+    },
+    {
+      "name": "Dan Tith",
+      "age": 23
+    }
+  ],
+  "null": null,
+  "null_str": "null"
+}

--- a/test/datatypes-simple/test.yaml
+++ b/test/datatypes-simple/test.yaml
@@ -1,0 +1,88 @@
+# 
+# These are the simple data types you will find in json. 
+# JSON's Basic Types According to http://en.wikipedia.org/wiki/JSON#Data_types.2C_syntax_and_example is:
+#  - Number (No distinction between floats and integer)
+#  - String ( "this is a string" )
+#  - Boolean ( either [true, false] only)
+#  - Array ( ordered list of values )
+#  - Object (unordered collections of key:value pairs) 
+#  - Null (no objects)
+
+
+## Integer
+
+integer: 123                      # an integer/number
+integer_str: "123"                # a string, disambiguated by quotes
+
+
+## Floats
+
+float_1: 123.0                      # a float
+float_2: 123.123                    # a float
+float_float: !!float 123.123      # also a float via explicit data type prefixed by (!!)
+float_str: "123.123"              # a string, disambiguated by quotes. Not a float.
+
+
+## Strings
+
+string_1: !!str 123               # a string, disambiguated by explicit type
+string_2: !!str Yes               # a string via explicit type
+string_3: Yes we have No bananas  # a string, "Yes" and "No" disambiguated by context.
+
+string_multiline: |
+   This is a multiline
+   in yaml source
+   it is made up of 
+   lots of lines
+
+string_folded: >
+   This is a multiline
+   in yaml source
+   it is made up of 
+   lots of lines
+
+## Boolean
+
+bool_true_1: true
+bool_true_2: Yes
+
+bool_false_1: false
+bool_false_2: No
+
+
+### ARRAY ###
+
+array_1: [1,2,3,4,5]              # a array sequence. inline
+
+array_2:                          # a array sequence.  
+  - 1
+  - 2
+  - 3
+  - 4
+  - 5
+  
+### ASSOCIATIVE LISTS (Eqv to object in json) ###
+
+associative_list: {name: John Smith, age: 33}
+
+  
+### ARRAY OF ASSOCIATIVE LISTS ##
+
+assoc_array_1:
+  - name: Mary Smith
+    age: 27
+  - name: Dan Tith
+    age: 23
+
+assoc_array_2:
+  - 
+    name: Mary Smith
+    age: 27
+  - 
+    name: Dan Tith
+    age: 23
+
+### NULL ###
+
+null: null
+null_str: "null"

--- a/test/mapping-block-simple/info
+++ b/test/mapping-block-simple/info
@@ -1,0 +1,9 @@
+This test mapping block capability of YAML.
+
+A mapping block, is a set of key:value pairs that looks like .
+
+```
+json: data exchange
+yaml: data serialization
+xml: textual data markup
+```

--- a/test/sequence-block-simple/info
+++ b/test/sequence-block-simple/info
@@ -1,0 +1,2 @@
+This test the "sequence block" syntax
+

--- a/test/string-block-simple/info
+++ b/test/string-block-simple/info
@@ -1,0 +1,12 @@
+This test the ability of YAML to deal with string data
+
+Also test the ability to quote/unquote a string. Also checks if literal or folded blok j
+
+	string_unquoted: This is a single lined string
+	string_quoted: "This is a single lined string"
+	literal: |
+		A literal block keeps all
+		new lines.
+	folded: >
+		A folded block will get rid
+		of its newlines.	

--- a/test/string-block-simple/test.json
+++ b/test/string-block-simple/test.json
@@ -1,0 +1,6 @@
+{
+  "string_unquoted": "This is a single lined string",
+  "string_quoted": "This is a single lined string",
+  "literal": "A literal block keeps all\nnew lines.\n",
+  "folded": "A folded block will get rid of its newlines.\n"
+}

--- a/test/string-block-simple/test.yaml
+++ b/test/string-block-simple/test.yaml
@@ -1,0 +1,8 @@
+string_unquoted: This is a single lined string
+string_quoted: "This is a single lined string"
+literal: |
+    A literal block keeps all
+    new lines.
+folded: >
+    A folded block will get rid
+    of its newlines.


### PR DESCRIPTION
Okay, hopefully this works. First push. A simple test case for strings.

So if I understand, tag folders contains a symbolic link to a mix of test cases to try out. What is the difference between the "simple" tag and the "lite" tag?

---

edit: also added another pull request, which I think is more useful. It test all the basic datatypes that is found in json. So at the minimum, yaml-lite or whatever the reduced spec is called, should work like that.
